### PR TITLE
Add contact page consistent with existing theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,9 +9,10 @@
   <!--
     - primary meta tags
   -->
-  <title>Grilli - Contact Us</title>
-  <meta name="title" content="Grilli - Contact Us">
-  <meta name="description" content="Connect with the Grilli team for reservations, events, and inquiries.">
+  <title>Grilli - About Us</title>
+  <meta name="title" content="Grilli - About Us">
+  <meta name="description"
+    content="Learn about Grilli's culinary philosophy, sustainable sourcing, and the hospitality that shapes every dining experience.">
 
   <!--
     - favicon
@@ -33,7 +34,7 @@
   <!--
     - preload images
   -->
-  <link rel="preload" as="image" href="./assets/images/hero-slider-3.jpg">
+  <link rel="preload" as="image" href="./assets/images/about-banner.jpg">
 </head>
 
 <body id="top">
@@ -139,7 +140,7 @@
           </li>
 
           <li class="navbar-item">
-            <a href="about.html" class="navbar-link hover-underline">
+            <a href="about.html" class="navbar-link hover-underline active" aria-current="page">
               <div class="separator"></div>
 
               <span class="span">About Us</span>
@@ -155,7 +156,7 @@
           </li>
 
           <li class="navbar-item">
-            <a href="contact.html" class="navbar-link hover-underline active">
+            <a href="contact.html" class="navbar-link hover-underline">
               <div class="separator"></div>
 
               <span class="span">Contact</span>
@@ -213,16 +214,16 @@
         - #PAGE HERO
       -->
 
-      <section class="section page-header has-bg-image text-center" aria-label="contact hero"
-        style="background-image: url('./assets/images/hero-slider-3.jpg')">
+      <section class="section page-header has-bg-image text-center" aria-label="about hero"
+        style="background-image: url('./assets/images/about-banner.jpg')">
         <div class="container">
-          <p class="section-subtitle label-2">Contact</p>
+          <p class="section-subtitle label-2">Our Story</p>
 
-          <h1 class="headline-1">We'd Love To Hear From You</h1>
+          <h1 class="headline-1">Crafted With Heart Since 2005</h1>
 
           <p class="section-text body-2">
-            Whether you are planning a celebration, booking a private dinner, or simply craving our signature dishes,
-            the Grilli team is ready to help.
+            From humble beginnings to a celebrated dining destination, Grilli is rooted in community, craft, and
+            hospitality.
           </p>
         </div>
       </section>
@@ -230,95 +231,87 @@
 
 
       <!--
-        - #CONTACT DETAILS
+        - #ABOUT STORY
       -->
 
-      <section class="section contact-details" aria-label="contact details">
+      <section class="section about-story" aria-label="about grilli">
         <div class="container">
-          <div class="contact-wrapper">
-            <div class="contact-info">
-              <p class="section-subtitle label-2">Reach Out</p>
+          <div class="story-content">
+            <p class="section-subtitle label-2">Who We Are</p>
 
-              <h2 class="headline-1 section-title">Visit Our Restaurant</h2>
+            <h2 class="headline-1 section-title">Every Flavor Tells A Chapter</h2>
 
-              <p class="section-text">
-                Get in touch for reservations, private dining, or any questions about our seasonal menus. Our hospitality
-                team is always delighted to assist you.
-              </p>
+            <p class="section-text">
+              Grilli was founded by friends who believed that a meal could be both comforting and daring. Today, our team
+              of chefs, farmers, and artisans collaborate closely to honor ingredients at their peak.
+            </p>
 
-              <ul class="contact-list">
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="location-outline" aria-hidden="true"></ion-icon>
-                    </div>
+            <p class="section-text">
+              We blend global culinary inspiration with local partnerships, ensuring that every plate reflects a balance of
+              innovation and warmth. The dining room is our stage, and our guests are always the stars of the evening.
+            </p>
 
-                    <div>
-                      <p class="card-title title-2">Restaurant Address</p>
+            <ul class="about-feature-list">
+              <li class="feature-card">
+                <div class="card-icon">
+                  <img src="./assets/images/features-icon-1.png" width="32" height="32" loading="lazy" alt="Fresh produce icon">
+                </div>
+                <div>
+                  <p class="title-3">Fresh Ingredients</p>
+                  <p class="body-4">Daily deliveries from trusted farmers, fisheries, and foragers.</p>
+                </div>
+              </li>
 
-                      <address class="body-4">
-                        Restaurant St, Delicious City, <br>
-                        London 9578, UK
-                      </address>
-                    </div>
-                  </div>
-                </li>
+              <li class="feature-card">
+                <div class="card-icon">
+                  <img src="./assets/images/features-icon-2.png" width="32" height="32" loading="lazy" alt="Chef hat icon">
+                </div>
+                <div>
+                  <p class="title-3">Expert Craft</p>
+                  <p class="body-4">A kitchen brigade with Michelin-level experience across three continents.</p>
+                </div>
+              </li>
 
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="call-outline" aria-hidden="true"></ion-icon>
-                    </div>
+              <li class="feature-card">
+                <div class="card-icon">
+                  <img src="./assets/images/features-icon-3.png" width="32" height="32" loading="lazy" alt="Leaf icon">
+                </div>
+                <div>
+                  <p class="title-3">Sustainable Focus</p>
+                  <p class="body-4">We reduce waste, repurpose ingredients, and champion ethical sourcing.</p>
+                </div>
+              </li>
+            </ul>
 
-                    <div>
-                      <p class="card-title title-2">Phone Numbers</p>
+            <div class="story-cta">
+              <div>
+                <p class="contact-label">Book Through Call</p>
+                <a href="tel:+804001234567" class="body-1 contact-number hover-underline">+80 (400) 123 4567</a>
+              </div>
 
-                      <a href="tel:+88123123456" class="body-4 contact-link hover-underline">Booking Request :
-                        +88-123-123456</a>
-                      <a href="tel:+84912345678" class="body-4 contact-link hover-underline">General Inquiries :
-                        +84 912 345 678</a>
-                    </div>
-                  </div>
-                </li>
+              <a href="menu.html" class="btn btn-primary">
+                <span class="text text-1">Explore Menu</span>
 
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
-                    </div>
-
-                    <div>
-                      <p class="card-title title-2">Email</p>
-
-                      <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
-                      <a href="mailto:hello@grilli.example" class="body-4 contact-link hover-underline">hello@grilli.example</a>
-                    </div>
-                  </div>
-                </li>
-
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
-                    </div>
-
-                    <div>
-                      <p class="card-title title-2">Opening Hours</p>
-
-                      <p class="body-4">Lunch : 11.00 am - 2.30 pm</p>
-                      <p class="body-4">Dinner : 05.00 pm - 10.00 pm</p>
-                    </div>
-                  </div>
-                </li>
-              </ul>
+                <span class="text text-2" aria-hidden="true">Explore Menu</span>
+              </a>
             </div>
+          </div>
 
-            <div class="contact-map">
-              <iframe
-                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1984.8453999382092!2d-0.12764738461290486!3d51.507321979635524!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b3339a9a6b9%3A0xdeb6a9d8b2666eb!2sLondon%2C%20UK!5e0!3m2!1sen!2suk!4v1697040000000!5m2!1sen!2suk"
-                width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade" title="Grilli restaurant on Google Maps"></iframe>
-            </div>
+          <div class="story-gallery">
+            <figure class="gallery-card large">
+              <img src="./assets/images/event-1.jpg" width="460" height="520" loading="lazy" alt="Guests enjoying dinner"
+                class="img-cover">
+            </figure>
+
+            <figure class="gallery-card">
+              <img src="./assets/images/event-2.jpg" width="280" height="320" loading="lazy" alt="Plating of a dish"
+                class="img-cover">
+            </figure>
+
+            <figure class="gallery-card">
+              <img src="./assets/images/event-3.jpg" width="280" height="320" loading="lazy" alt="Sommelier pouring wine"
+                class="img-cover">
+            </figure>
           </div>
         </div>
       </section>
@@ -326,66 +319,43 @@
 
 
       <!--
-        - #CONTACT FORM
+        - #VALUES
       -->
 
-      <section class="section contact-form" aria-label="contact form">
+      <section class="section about-values" aria-label="grilli values">
         <div class="container">
-          <div class="form reservation-form bg-black-10">
-
-            <form action="" class="form-left">
-              <h2 class="headline-1 text-center">Send A Message</h2>
-
-              <p class="form-text text-center">
-                Prefer to write? Share your message below and a member of the Grilli team will reply shortly.
+          <div class="values-card bg-black-10">
+            <div>
+              <p class="section-subtitle label-2">Our Promise</p>
+              <h2 class="headline-1 section-title">Hospitality Beyond The Plate</h2>
+              <p class="section-text">
+                Whether you join us for a casual lunch or a milestone celebration, our team delivers thoughtful service,
+                curated pairings, and a vibrant atmosphere tailored to your moment.
               </p>
-
-              <div class="input-wrapper">
-                <input type="text" name="full-name" placeholder="Your Name" autocomplete="off" class="input-field">
-
-                <input type="email" name="email" placeholder="Email Address" autocomplete="off" class="input-field">
-              </div>
-
-              <div class="input-wrapper">
-                <input type="tel" name="phone" placeholder="Phone Number" autocomplete="off" class="input-field">
-
-                <input type="text" name="subject" placeholder="Subject" autocomplete="off" class="input-field">
-              </div>
-
-              <textarea name="message" placeholder="Message" autocomplete="off" class="input-field"></textarea>
-
-              <button type="submit" class="btn btn-secondary">
-                <span class="text text-1">Send Message</span>
-
-                <span class="text text-2" aria-hidden="true">Send Message</span>
-              </button>
-            </form>
-
-            <div class="form-right text-center" style="background-image: url('./assets/images/form-pattern.png')">
-
-              <h2 class="headline-1 text-center">Booking Request</h2>
-
-              <p class="contact-label">Call Us</p>
-
-              <a href="tel:+88123123456" class="body-1 contact-number hover-underline">+88-123-123456</a>
-
-              <div class="separator"></div>
-
-              <p class="contact-label">Email</p>
-
-              <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
-
-              <div class="separator"></div>
-
-              <p class="contact-label">Opening Hours</p>
-
-              <p class="body-4">
-                Monday to Sunday <br>
-                11.00 am - 10.00 pm
-              </p>
-
             </div>
 
+            <div class="values-list">
+              <div>
+                <p class="title-3">Seasonal Menus</p>
+                <p class="body-4">Quarterly updates that highlight local harvests and regional traditions.</p>
+              </div>
+
+              <div>
+                <p class="title-3">Private Dining</p>
+                <p class="body-4">Intimate rooms with bespoke menus and sommelier-guided pairings.</p>
+              </div>
+
+              <div>
+                <p class="title-3">Community Support</p>
+                <p class="body-4">Collaborations with neighborhood nonprofits and culinary schools.</p>
+              </div>
+            </div>
+
+            <a href="contact.html" class="btn btn-secondary">
+              <span class="text text-1">Plan An Event</span>
+
+              <span class="text text-2" aria-hidden="true">Plan An Event</span>
+            </a>
           </div>
         </div>
       </section>
@@ -399,8 +369,7 @@
     - #FOOTER
   -->
 
-  <footer class="footer section has-bg-image text-center"
-    style="background-image: url('./assets/images/footer-bg.jpg')">
+  <footer class="footer section has-bg-image" style="background-image: url('./assets/images/footer-bg.jpg')">
     <div class="container">
 
       <div class="footer-top grid-list">
@@ -505,8 +474,8 @@
       <div class="footer-bottom">
 
         <p class="copyright">
-          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee"
-            target="_blank" class="link">codewithsadee</a>
+          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee" target="_blank"
+            class="link">codewithsadee</a>
         </p>
 
       </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1505,6 +1505,262 @@ textarea.input-field {
 }
 
 /*-----------------------------------*\
+  #MENU PAGE
+\*-----------------------------------*/
+
+[hidden] { display: none !important; }
+
+.menu-page .section-title { margin-block-end: 12px; }
+
+.filter-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 15px;
+  margin-block: 32px 40px;
+}
+
+.filter-btn {
+  padding: 12px 26px;
+  border-radius: 99px;
+  border: 1px solid var(--white-alpha-10);
+  background-color: transparent;
+  color: var(--quick-silver);
+  text-transform: uppercase;
+  letter-spacing: var(--letterSpacing-3);
+  transition: var(--transition-1);
+}
+
+.filter-btn:is(:hover, :focus-visible),
+.filter-btn.active {
+  color: var(--black);
+  background-color: var(--gold-crayola);
+  border-color: var(--gold-crayola);
+}
+
+.menu-page .grid-list { margin-block-end: 40px; }
+
+.menu-page .menu-card {
+  height: 100%;
+  border: 1px solid var(--white-alpha-10);
+}
+
+.menu-page .menu-card:hover { border-color: var(--gold-crayola); }
+
+.menu-page .menu-card .title-wrapper {
+  align-items: center;
+  gap: 16px;
+}
+
+.menu-empty {
+  text-align: center;
+  color: var(--quick-silver);
+}
+
+.menu-cta-card {
+  display: grid;
+  gap: 30px;
+  padding: 40px;
+  border-radius: var(--radius-24);
+  border: 1px solid var(--white-alpha-10);
+  align-items: center;
+}
+
+.menu-cta-card .section-text { color: var(--quick-silver); }
+
+/*-----------------------------------*\
+  #CHEFS PAGE
+\*-----------------------------------*/
+
+.chefs-grid {
+  margin-block-start: 50px;
+}
+
+.chef-card {
+  width: 100%;
+  text-align: left;
+  background-color: var(--smoky-black-2);
+  border: 1px solid var(--white-alpha-10);
+  border-radius: var(--radius-24);
+  overflow: hidden;
+  transition: var(--transition-2);
+}
+
+.chef-card .card-banner { transition: var(--transition-2); }
+
+.chef-card .card-content {
+  padding: 30px 32px 36px;
+  display: grid;
+  gap: 10px;
+}
+
+.chef-card .btn-text { justify-self: flex-start; }
+
+.chef-card:is(:hover, :focus-visible) {
+  transform: translateY(-6px);
+  border-color: var(--gold-crayola);
+}
+
+.chef-card:is(:hover, :focus-visible) .card-banner {
+  transform: scale(1.05);
+}
+
+.chef-card .label-2 { color: var(--gold-crayola); }
+
+.chef-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 30px 16px;
+  opacity: 0;
+  visibility: hidden;
+  transition: var(--transition-2);
+}
+
+.chef-modal.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.chef-modal .modal-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: var(--black-alpha-80);
+}
+
+.chef-modal .modal-content {
+  position: relative;
+  z-index: 1;
+  background-color: var(--smoky-black-2);
+  border: 1px solid var(--white-alpha-10);
+  border-radius: var(--radius-24);
+  overflow: hidden;
+  display: grid;
+  gap: 0;
+  max-width: 860px;
+  width: min(100%, 860px);
+}
+
+.chef-modal .modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-circle);
+  background-color: var(--black-alpha-15);
+  color: var(--white);
+  display: grid;
+  place-items: center;
+  transition: var(--transition-1);
+}
+
+.chef-modal .modal-close:is(:hover, :focus-visible) {
+  background-color: var(--gold-crayola);
+  color: var(--black);
+}
+
+.chef-modal .modal-media { aspect-ratio: 6 / 5; }
+
+.chef-modal .modal-body {
+  padding: 40px 32px 48px;
+  display: grid;
+  gap: 16px;
+}
+
+.chef-modal .modal-body .label-2 { color: var(--gold-crayola); }
+
+.modal-specialty {
+  color: var(--quick-silver);
+  border-top: 1px solid var(--white-alpha-10);
+  padding-block-start: 16px;
+}
+
+body.modal-active { overflow: hidden; }
+
+/*-----------------------------------*\
+  #ABOUT PAGE
+\*-----------------------------------*/
+
+.about-story .container {
+  display: grid;
+  gap: 50px;
+}
+
+.story-content {
+  display: grid;
+  gap: 20px;
+}
+
+.story-content .section-text { color: var(--quick-silver); }
+
+.about-feature-list {
+  display: grid;
+  gap: 20px;
+  margin-block: 10px 20px;
+}
+
+.feature-card {
+  display: flex;
+  gap: 16px;
+  padding: 18px 22px;
+  background-color: var(--smoky-black-2);
+  border: 1px solid var(--white-alpha-10);
+  border-radius: var(--radius-24);
+}
+
+.feature-card .card-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-circle);
+  background-color: var(--white-alpha-10);
+  display: grid;
+  place-items: center;
+}
+
+.feature-card .body-4 { color: var(--quick-silver); }
+
+.story-cta {
+  display: grid;
+  gap: 24px;
+  align-items: center;
+}
+
+.story-gallery {
+  display: grid;
+  gap: 24px;
+}
+
+.story-gallery .gallery-card {
+  border-radius: var(--radius-24);
+  overflow: hidden;
+  border: 1px solid var(--white-alpha-10);
+}
+
+.story-gallery .gallery-card.large { grid-row: span 2; }
+
+.about-values .values-card {
+  display: grid;
+  gap: 32px;
+  padding: 40px;
+  border-radius: var(--radius-24);
+  border: 1px solid var(--white-alpha-10);
+}
+
+.about-values .section-text { color: var(--quick-silver); }
+
+.values-list {
+  display: grid;
+  gap: 24px;
+}
+
+.values-list .body-4 { color: var(--quick-silver); }
+
+
+/*-----------------------------------*\
   #BACK TO TOP
 \*-----------------------------------*/
 
@@ -1755,6 +2011,17 @@ textarea.input-field {
 
   .grid-list { grid-template-columns: 1fr 1fr; }
 
+  .menu-page .grid-list,
+  .chefs-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+  .story-gallery { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+  .story-cta {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 30px;
+  }
+
   .contact-list { grid-template-columns: 1fr 1fr; }
 
   .page-header { padding-block: 220px 140px; }
@@ -1872,6 +2139,19 @@ textarea.input-field {
     width: 100%;
   }
 
+  .menu-page .grid-list { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+  .chefs-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+  .menu-cta-card {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+
+  .chef-modal .modal-content { grid-template-columns: 0.85fr 1fr; }
+
+  .chef-modal .modal-media { aspect-ratio: 4 / 5; }
+
   .contact-wrapper {
     grid-template-columns: 1fr 1fr;
     align-items: start;
@@ -1917,6 +2197,14 @@ textarea.input-field {
     grid-template-columns: 0.7fr 1fr;
     gap: 30px;
   }
+
+  .about-story .container {
+    grid-template-columns: 1.1fr 1fr;
+    align-items: center;
+    gap: 60px;
+  }
+
+  .story-gallery { align-self: stretch; }
 
 
 
@@ -1965,6 +2253,8 @@ textarea.input-field {
     height: 100%;
     border-inline-start: 1px solid var(--white-alpha-20);
   }
+
+  .values-list { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 
 
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1398,6 +1398,113 @@ textarea.input-field {
 
 
 /*-----------------------------------*\
+  #CONTACT
+\*-----------------------------------*/
+
+.page-header {
+  padding-block: 180px 120px;
+  color: var(--white);
+}
+
+.page-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(180deg, var(--black-alpha-80), transparent 60%);
+}
+
+.page-header .container {
+  position: relative;
+  z-index: 1;
+}
+
+.page-header .section-subtitle { color: var(--gold-crayola); }
+
+.page-header .headline-1 {
+  margin-block: 16px 20px;
+  letter-spacing: var(--letterSpacing-5);
+}
+
+.page-header .section-text {
+  max-width: 620px;
+  margin-inline: auto;
+  color: var(--quick-silver);
+}
+
+.contact-details .section-title { margin-block: 10px 20px; }
+
+.contact-details .section-text {
+  color: var(--quick-silver);
+  max-width: 520px;
+}
+
+.contact-wrapper {
+  display: grid;
+  gap: 40px;
+}
+
+.contact-list {
+  display: grid;
+  gap: 20px;
+  margin-block-start: 40px;
+}
+
+.contact-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 30px;
+  background-color: var(--smoky-black-2);
+  border: 1px solid var(--white-alpha-10);
+  border-radius: var(--radius-24);
+  transition: var(--transition-1);
+}
+
+.contact-card:hover {
+  border-color: var(--gold-crayola);
+  transform: translateY(-4px);
+}
+
+.contact-card .card-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-circle);
+  display: grid;
+  place-items: center;
+  background-color: var(--white-alpha-10);
+  color: var(--gold-crayola);
+  font-size: 2.4rem;
+  flex-shrink: 0;
+}
+
+.contact-card .card-title { margin-block-end: 10px; }
+
+.contact-card :is(.body-4, .contact-link) { color: var(--quick-silver); }
+
+.contact-card .contact-link { transition: var(--transition-1); }
+
+.contact-card .contact-link:is(:hover, :focus-visible) { color: var(--gold-crayola); }
+
+.contact-map {
+  border: 1px solid var(--white-alpha-10);
+  border-radius: var(--radius-24);
+  overflow: hidden;
+  min-height: 340px;
+  box-shadow: var(--shadow-1);
+}
+
+.contact-map iframe {
+  width: 100%;
+  height: 100%;
+  filter: grayscale(0.2) contrast(1.05);
+}
+
+.contact-form .form-text {
+  color: var(--quick-silver);
+  margin-block: 10px 30px;
+}
+
+/*-----------------------------------*\
   #BACK TO TOP
 \*-----------------------------------*/
 
@@ -1648,6 +1755,10 @@ textarea.input-field {
 
   .grid-list { grid-template-columns: 1fr 1fr; }
 
+  .contact-list { grid-template-columns: 1fr 1fr; }
+
+  .page-header { padding-block: 220px 140px; }
+
   :is(.service, .event) .container { max-width: 820px; }
 
   :is(.service, .event) .grid-list li:last-child {
@@ -1760,6 +1871,13 @@ textarea.input-field {
     grid-column: auto;
     width: 100%;
   }
+
+  .contact-wrapper {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+
+  .contact-map { min-height: 100%; }
 
 
 
@@ -1927,6 +2045,12 @@ textarea.input-field {
     width: 100%;
     margin-inline: auto;
   }
+
+  .page-header { padding-block: 260px 160px; }
+
+  .contact-wrapper { column-gap: 80px; }
+
+  .contact-card { padding: 35px 40px; }
 
 
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -10,10 +10,12 @@
 
 const preloader = document.querySelector("[data-preaload]");
 
-window.addEventListener("load", function () {
-  preloader.classList.add("loaded");
-  document.body.classList.add("loaded");
-});
+if (preloader) {
+  window.addEventListener("load", function () {
+    preloader.classList.add("loaded");
+    document.body.classList.add("loaded");
+  });
+}
 
 
 
@@ -37,13 +39,15 @@ const navbar = document.querySelector("[data-navbar]");
 const navTogglers = document.querySelectorAll("[data-nav-toggler]");
 const overlay = document.querySelector("[data-overlay]");
 
-const toggleNavbar = function () {
-  navbar.classList.toggle("active");
-  overlay.classList.toggle("active");
-  document.body.classList.toggle("nav-active");
-}
+if (navbar && overlay && navTogglers.length) {
+  const toggleNavbar = function () {
+    navbar.classList.toggle("active");
+    overlay.classList.toggle("active");
+    document.body.classList.toggle("nav-active");
+  }
 
-addEventOnElements(navTogglers, "click", toggleNavbar);
+  addEventOnElements(navTogglers, "click", toggleNavbar);
+}
 
 
 
@@ -89,58 +93,57 @@ const heroSliderItems = document.querySelectorAll("[data-hero-slider-item]");
 const heroSliderPrevBtn = document.querySelector("[data-prev-btn]");
 const heroSliderNextBtn = document.querySelector("[data-next-btn]");
 
-let currentSlidePos = 0;
-let lastActiveSliderItem = heroSliderItems[0];
+if (heroSlider && heroSliderItems.length && heroSliderPrevBtn && heroSliderNextBtn) {
+  let currentSlidePos = 0;
+  let lastActiveSliderItem = heroSliderItems[0];
 
-const updateSliderPos = function () {
-  lastActiveSliderItem.classList.remove("active");
-  heroSliderItems[currentSlidePos].classList.add("active");
-  lastActiveSliderItem = heroSliderItems[currentSlidePos];
-}
-
-const slideNext = function () {
-  if (currentSlidePos >= heroSliderItems.length - 1) {
-    currentSlidePos = 0;
-  } else {
-    currentSlidePos++;
+  const updateSliderPos = function () {
+    lastActiveSliderItem.classList.remove("active");
+    heroSliderItems[currentSlidePos].classList.add("active");
+    lastActiveSliderItem = heroSliderItems[currentSlidePos];
   }
 
-  updateSliderPos();
-}
+  const slideNext = function () {
+    if (currentSlidePos >= heroSliderItems.length - 1) {
+      currentSlidePos = 0;
+    } else {
+      currentSlidePos++;
+    }
 
-heroSliderNextBtn.addEventListener("click", slideNext);
-
-const slidePrev = function () {
-  if (currentSlidePos <= 0) {
-    currentSlidePos = heroSliderItems.length - 1;
-  } else {
-    currentSlidePos--;
+    updateSliderPos();
   }
 
-  updateSliderPos();
+  const slidePrev = function () {
+    if (currentSlidePos <= 0) {
+      currentSlidePos = heroSliderItems.length - 1;
+    } else {
+      currentSlidePos--;
+    }
+
+    updateSliderPos();
+  }
+
+  heroSliderNextBtn.addEventListener("click", slideNext);
+  heroSliderPrevBtn.addEventListener("click", slidePrev);
+
+  /**
+   * auto slide
+   */
+
+  let autoSlideInterval;
+
+  const autoSlide = function () {
+    autoSlideInterval = setInterval(slideNext, 7000);
+  }
+
+  addEventOnElements([heroSliderNextBtn, heroSliderPrevBtn], "mouseover", function () {
+    clearInterval(autoSlideInterval);
+  });
+
+  addEventOnElements([heroSliderNextBtn, heroSliderPrevBtn], "mouseout", autoSlide);
+
+  window.addEventListener("load", autoSlide);
 }
-
-heroSliderPrevBtn.addEventListener("click", slidePrev);
-
-/**
- * auto slide
- */
-
-let autoSlideInterval;
-
-const autoSlide = function () {
-  autoSlideInterval = setInterval(function () {
-    slideNext();
-  }, 7000);
-}
-
-addEventOnElements([heroSliderNextBtn, heroSliderPrevBtn], "mouseover", function () {
-  clearInterval(autoSlideInterval);
-});
-
-addEventOnElements([heroSliderNextBtn, heroSliderPrevBtn], "mouseout", autoSlide);
-
-window.addEventListener("load", autoSlide);
 
 
 
@@ -152,19 +155,150 @@ const parallaxItems = document.querySelectorAll("[data-parallax-item]");
 
 let x, y;
 
-window.addEventListener("mousemove", function (event) {
+if (parallaxItems.length) {
+  window.addEventListener("mousemove", function (event) {
 
-  x = (event.clientX / window.innerWidth * 10) - 5;
-  y = (event.clientY / window.innerHeight * 10) - 5;
+    x = (event.clientX / window.innerWidth * 10) - 5;
+    y = (event.clientY / window.innerHeight * 10) - 5;
 
-  // reverse the number eg. 20 -> -20, -5 -> 5
-  x = x - (x * 2);
-  y = y - (y * 2);
+    // reverse the number eg. 20 -> -20, -5 -> 5
+    x = x - (x * 2);
+    y = y - (y * 2);
 
-  for (let i = 0, len = parallaxItems.length; i < len; i++) {
-    x = x * Number(parallaxItems[i].dataset.parallaxSpeed);
-    y = y * Number(parallaxItems[i].dataset.parallaxSpeed);
-    parallaxItems[i].style.transform = `translate3d(${x}px, ${y}px, 0px)`;
+    for (let i = 0, len = parallaxItems.length; i < len; i++) {
+      const speed = Number(parallaxItems[i].dataset.parallaxSpeed || 1);
+      const offsetX = x * speed;
+      const offsetY = y * speed;
+      parallaxItems[i].style.transform = `translate3d(${offsetX}px, ${offsetY}px, 0px)`;
+    }
+
+  });
+}
+
+
+/**
+ * MENU FILTER
+ */
+
+const menuFilterContainer = document.querySelector("[data-menu-filter]");
+
+if (menuFilterContainer) {
+  const filterButtons = menuFilterContainer.querySelectorAll("[data-filter-btn]");
+  const menuItems = document.querySelectorAll("[data-menu-item]");
+  const emptyState = menuFilterContainer.querySelector("[data-menu-empty]");
+
+  const filterMenu = function (category) {
+    const normalizedCategory = category ? category.toLowerCase() : "all";
+    let visibleCount = 0;
+
+    menuItems.forEach(function (item) {
+      const itemCategory = (item.dataset.category || "").toLowerCase();
+      const shouldShow = normalizedCategory === "all" || itemCategory === normalizedCategory;
+      item.toggleAttribute("hidden", !shouldShow);
+
+      if (shouldShow) {
+        visibleCount++;
+      }
+    });
+
+    if (emptyState) {
+      emptyState.toggleAttribute("hidden", visibleCount !== 0);
+    }
   }
 
-});
+  filterButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      filterButtons.forEach(function (btn) {
+        btn.classList.remove("active");
+        btn.setAttribute("aria-selected", "false");
+      });
+
+      button.classList.add("active");
+      button.setAttribute("aria-selected", "true");
+
+      filterMenu(button.dataset.filter || "all");
+    });
+  });
+
+  const defaultCategory = menuFilterContainer.querySelector("[data-filter-btn].active")?.dataset.filter || "all";
+  filterMenu(defaultCategory);
+}
+
+
+/**
+ * CHEF MODAL
+ */
+
+const chefCards = document.querySelectorAll("[data-chef-card]");
+const chefModal = document.querySelector("[data-chef-modal]");
+
+if (chefCards.length && chefModal) {
+  const modalOverlay = chefModal.querySelector("[data-modal-overlay]");
+  const modalClose = chefModal.querySelector("[data-modal-close]");
+  const modalImg = chefModal.querySelector("[data-modal-img]");
+  const modalName = chefModal.querySelector("[data-modal-name]");
+  const modalRole = chefModal.querySelector("[data-modal-role]");
+  const modalBio = chefModal.querySelector("[data-modal-bio]");
+  const modalSpecialty = chefModal.querySelector("[data-modal-specialty]");
+
+  const closeModal = function () {
+    chefModal.classList.remove("active");
+    document.body.classList.remove("modal-active");
+    window.removeEventListener("keydown", handleKeydown);
+  }
+
+  const handleKeydown = function (event) {
+    if (event.key === "Escape") {
+      closeModal();
+    }
+  }
+
+  const openModal = function (card) {
+    const { image, name, role, bio, specialty } = card.dataset;
+
+    if (modalImg && image) {
+      modalImg.src = image;
+      modalImg.alt = name ? `Portrait of ${name}` : "Chef portrait";
+    }
+
+    if (modalName && name) {
+      modalName.textContent = name;
+    }
+
+    if (modalRole) {
+      modalRole.textContent = role || "";
+    }
+
+    if (modalBio) {
+      modalBio.textContent = bio || "";
+    }
+
+    if (modalSpecialty) {
+      if (specialty) {
+        modalSpecialty.textContent = `Specialty: ${specialty}`;
+        modalSpecialty.removeAttribute("hidden");
+      } else {
+        modalSpecialty.textContent = "";
+        modalSpecialty.setAttribute("hidden", "");
+      }
+    }
+
+    chefModal.classList.add("active");
+    document.body.classList.add("modal-active");
+    window.addEventListener("keydown", handleKeydown);
+  }
+
+  chefCards.forEach(function (card) {
+    card.addEventListener("click", function () {
+      openModal(card);
+    });
+  });
+
+  if (modalOverlay) {
+    modalOverlay.addEventListener("click", closeModal);
+  }
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+}

--- a/chefs.html
+++ b/chefs.html
@@ -9,9 +9,9 @@
   <!--
     - primary meta tags
   -->
-  <title>Grilli - Contact Us</title>
-  <meta name="title" content="Grilli - Contact Us">
-  <meta name="description" content="Connect with the Grilli team for reservations, events, and inquiries.">
+  <title>Grilli - Our Chefs</title>
+  <meta name="title" content="Grilli - Our Chefs">
+  <meta name="description" content="Meet the masterful culinary team behind Grilli's signature dishes and seasonal tasting menus.">
 
   <!--
     - favicon
@@ -33,7 +33,7 @@
   <!--
     - preload images
   -->
-  <link rel="preload" as="image" href="./assets/images/hero-slider-3.jpg">
+  <link rel="preload" as="image" href="./assets/images/hero-slider-1.jpg">
 </head>
 
 <body id="top">
@@ -147,7 +147,7 @@
           </li>
 
           <li class="navbar-item">
-            <a href="chefs.html" class="navbar-link hover-underline">
+            <a href="chefs.html" class="navbar-link hover-underline active" aria-current="page">
               <div class="separator"></div>
 
               <span class="span">Our Chefs</span>
@@ -155,7 +155,7 @@
           </li>
 
           <li class="navbar-item">
-            <a href="contact.html" class="navbar-link hover-underline active">
+            <a href="contact.html" class="navbar-link hover-underline">
               <div class="separator"></div>
 
               <span class="span">Contact</span>
@@ -213,16 +213,15 @@
         - #PAGE HERO
       -->
 
-      <section class="section page-header has-bg-image text-center" aria-label="contact hero"
-        style="background-image: url('./assets/images/hero-slider-3.jpg')">
+      <section class="section page-header has-bg-image text-center" aria-label="chef hero"
+        style="background-image: url('./assets/images/hero-slider-1.jpg')">
         <div class="container">
-          <p class="section-subtitle label-2">Contact</p>
+          <p class="section-subtitle label-2">Our Team</p>
 
-          <h1 class="headline-1">We'd Love To Hear From You</h1>
+          <h1 class="headline-1">Culinary Artisans of Grilli</h1>
 
           <p class="section-text body-2">
-            Whether you are planning a celebration, booking a private dinner, or simply craving our signature dishes,
-            the Grilli team is ready to help.
+            Dedicated chefs, sommeliers, and artisans crafting unforgettable dining experiences every evening.
           </p>
         </div>
       </section>
@@ -230,165 +229,99 @@
 
 
       <!--
-        - #CONTACT DETAILS
+        - #CHEF GRID
       -->
 
-      <section class="section contact-details" aria-label="contact details">
+      <section class="section chefs" aria-label="chef profiles">
         <div class="container">
-          <div class="contact-wrapper">
-            <div class="contact-info">
-              <p class="section-subtitle label-2">Reach Out</p>
+          <p class="section-subtitle text-center label-2">Meet The Team</p>
 
-              <h2 class="headline-1 section-title">Visit Our Restaurant</h2>
+          <h2 class="headline-1 section-title text-center">Masters Behind The Flame</h2>
 
-              <p class="section-text">
-                Get in touch for reservations, private dining, or any questions about our seasonal menus. Our hospitality
-                team is always delighted to assist you.
-              </p>
+          <ul class="grid-list chefs-grid">
+            <li>
+              <button type="button" class="chef-card" data-chef-card data-name="Luca Moretti" data-role="Executive Chef"
+                data-specialty="Signature Tasting Menu" data-bio="Chef Luca leads the kitchen with a focus on seasonal produce, modern European techniques, and soulful hospitality." data-image="./assets/images/service-1.jpg">
+                <figure class="card-banner img-holder" style="--width: 350; --height: 420;">
+                  <img src="./assets/images/service-1.jpg" width="350" height="420" loading="lazy" alt="Chef Luca Moretti"
+                    class="img-cover">
+                </figure>
 
-              <ul class="contact-list">
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="location-outline" aria-hidden="true"></ion-icon>
-                    </div>
+                <div class="card-content">
+                  <p class="label-2">Executive Chef</p>
+                  <h3 class="title-3">Luca Moretti</h3>
+                  <p class="body-4">Guiding the brigade with precision and warmth.</p>
+                  <span class="btn-text">View Profile</span>
+                </div>
+              </button>
+            </li>
 
-                    <div>
-                      <p class="card-title title-2">Restaurant Address</p>
+            <li>
+              <button type="button" class="chef-card" data-chef-card data-name="Amelia Chen" data-role="Pastry Director"
+                data-specialty="Seasonal Desserts" data-bio="Chef Amelia layers classic pastry foundations with unexpected botanicals to create desserts that delight every sense." data-image="./assets/images/service-2.jpg">
+                <figure class="card-banner img-holder" style="--width: 350; --height: 420;">
+                  <img src="./assets/images/service-2.jpg" width="350" height="420" loading="lazy" alt="Chef Amelia Chen"
+                    class="img-cover">
+                </figure>
 
-                      <address class="body-4">
-                        Restaurant St, Delicious City, <br>
-                        London 9578, UK
-                      </address>
-                    </div>
-                  </div>
-                </li>
+                <div class="card-content">
+                  <p class="label-2">Pastry Director</p>
+                  <h3 class="title-3">Amelia Chen</h3>
+                  <p class="body-4">Balancing texture, aroma, and vibrant color.</p>
+                  <span class="btn-text">View Profile</span>
+                </div>
+              </button>
+            </li>
 
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="call-outline" aria-hidden="true"></ion-icon>
-                    </div>
+            <li>
+              <button type="button" class="chef-card" data-chef-card data-name="Mateo Silva" data-role="Chef de Cuisine"
+                data-specialty="Wood-Fired Grill" data-bio="Chef Mateo harmonizes fire and smoke to enhance responsibly sourced meats, seafood, and vegetables." data-image="./assets/images/service-3.jpg">
+                <figure class="card-banner img-holder" style="--width: 350; --height: 420;">
+                  <img src="./assets/images/service-3.jpg" width="350" height="420" loading="lazy" alt="Chef Mateo Silva"
+                    class="img-cover">
+                </figure>
 
-                    <div>
-                      <p class="card-title title-2">Phone Numbers</p>
-
-                      <a href="tel:+88123123456" class="body-4 contact-link hover-underline">Booking Request :
-                        +88-123-123456</a>
-                      <a href="tel:+84912345678" class="body-4 contact-link hover-underline">General Inquiries :
-                        +84 912 345 678</a>
-                    </div>
-                  </div>
-                </li>
-
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
-                    </div>
-
-                    <div>
-                      <p class="card-title title-2">Email</p>
-
-                      <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
-                      <a href="mailto:hello@grilli.example" class="body-4 contact-link hover-underline">hello@grilli.example</a>
-                    </div>
-                  </div>
-                </li>
-
-                <li>
-                  <div class="contact-card">
-                    <div class="card-icon">
-                      <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
-                    </div>
-
-                    <div>
-                      <p class="card-title title-2">Opening Hours</p>
-
-                      <p class="body-4">Lunch : 11.00 am - 2.30 pm</p>
-                      <p class="body-4">Dinner : 05.00 pm - 10.00 pm</p>
-                    </div>
-                  </div>
-                </li>
-              </ul>
-            </div>
-
-            <div class="contact-map">
-              <iframe
-                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1984.8453999382092!2d-0.12764738461290486!3d51.507321979635524!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b3339a9a6b9%3A0xdeb6a9d8b2666eb!2sLondon%2C%20UK!5e0!3m2!1sen!2suk!4v1697040000000!5m2!1sen!2suk"
-                width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade" title="Grilli restaurant on Google Maps"></iframe>
-            </div>
-          </div>
+                <div class="card-content">
+                  <p class="label-2">Chef de Cuisine</p>
+                  <h3 class="title-3">Mateo Silva</h3>
+                  <p class="body-4">Sourcing sustainably and plating with artistry.</p>
+                  <span class="btn-text">View Profile</span>
+                </div>
+              </button>
+            </li>
+          </ul>
         </div>
       </section>
 
 
 
       <!--
-        - #CONTACT FORM
+        - #CHEF MODAL
       -->
 
-      <section class="section contact-form" aria-label="contact form">
-        <div class="container">
-          <div class="form reservation-form bg-black-10">
+      <div class="chef-modal" data-chef-modal>
+        <div class="modal-overlay" data-modal-overlay></div>
+        <div class="modal-content">
+          <button type="button" class="modal-close" aria-label="Close chef details" data-modal-close>
+            <ion-icon name="close-outline" aria-hidden="true"></ion-icon>
+          </button>
 
-            <form action="" class="form-left">
-              <h2 class="headline-1 text-center">Send A Message</h2>
+          <figure class="modal-media">
+            <img src="./assets/images/service-1.jpg" width="360" height="420" alt="Chef portrait" class="img-cover"
+              data-modal-img>
+          </figure>
 
-              <p class="form-text text-center">
-                Prefer to write? Share your message below and a member of the Grilli team will reply shortly.
-              </p>
-
-              <div class="input-wrapper">
-                <input type="text" name="full-name" placeholder="Your Name" autocomplete="off" class="input-field">
-
-                <input type="email" name="email" placeholder="Email Address" autocomplete="off" class="input-field">
-              </div>
-
-              <div class="input-wrapper">
-                <input type="tel" name="phone" placeholder="Phone Number" autocomplete="off" class="input-field">
-
-                <input type="text" name="subject" placeholder="Subject" autocomplete="off" class="input-field">
-              </div>
-
-              <textarea name="message" placeholder="Message" autocomplete="off" class="input-field"></textarea>
-
-              <button type="submit" class="btn btn-secondary">
-                <span class="text text-1">Send Message</span>
-
-                <span class="text text-2" aria-hidden="true">Send Message</span>
-              </button>
-            </form>
-
-            <div class="form-right text-center" style="background-image: url('./assets/images/form-pattern.png')">
-
-              <h2 class="headline-1 text-center">Booking Request</h2>
-
-              <p class="contact-label">Call Us</p>
-
-              <a href="tel:+88123123456" class="body-1 contact-number hover-underline">+88-123-123456</a>
-
-              <div class="separator"></div>
-
-              <p class="contact-label">Email</p>
-
-              <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
-
-              <div class="separator"></div>
-
-              <p class="contact-label">Opening Hours</p>
-
-              <p class="body-4">
-                Monday to Sunday <br>
-                11.00 am - 10.00 pm
-              </p>
-
-            </div>
-
+          <div class="modal-body">
+            <p class="label-2" data-modal-role>Executive Chef</p>
+            <h3 class="headline-2" data-modal-name>Luca Moretti</h3>
+            <p class="body-4" data-modal-bio>
+              Chef Luca leads the kitchen with a focus on seasonal produce, modern European techniques, and soulful
+              hospitality.
+            </p>
+            <p class="body-4 modal-specialty" data-modal-specialty hidden>Specialty: Signature Tasting Menu</p>
           </div>
         </div>
-      </section>
+      </div>
 
     </article>
   </main>
@@ -399,8 +332,7 @@
     - #FOOTER
   -->
 
-  <footer class="footer section has-bg-image text-center"
-    style="background-image: url('./assets/images/footer-bg.jpg')">
+  <footer class="footer section has-bg-image" style="background-image: url('./assets/images/footer-bg.jpg')">
     <div class="container">
 
       <div class="footer-top grid-list">
@@ -505,8 +437,8 @@
       <div class="footer-bottom">
 
         <p class="copyright">
-          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee"
-            target="_blank" class="link">codewithsadee</a>
+          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee" target="_blank"
+            class="link">codewithsadee</a>
         </p>
 
       </div>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,542 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!--
+    - primary meta tags
+  -->
+  <title>Grilli - Contact Us</title>
+  <meta name="title" content="Grilli - Contact Us">
+  <meta name="description" content="Connect with the Grilli team for reservations, events, and inquiries.">
+
+  <!--
+    - favicon
+  -->
+  <link rel="shortcut icon" href="./favicon.svg" type="image/svg+xml">
+
+  <!--
+    - google font link
+  -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Forum&display=swap" rel="stylesheet">
+
+  <!--
+    - custom css link
+  -->
+  <link rel="stylesheet" href="./assets/css/style.css">
+
+  <!--
+    - preload images
+  -->
+  <link rel="preload" as="image" href="./assets/images/hero-slider-3.jpg">
+</head>
+
+<body id="top">
+
+  <!--
+    - #PRELOADER
+  -->
+
+  <div class="preload" data-preaload>
+    <div class="circle"></div>
+    <p class="text">Grilli</p>
+  </div>
+
+
+
+  <!--
+    - #TOP BAR
+  -->
+
+  <div class="topbar">
+    <div class="container">
+
+      <address class="topbar-item">
+        <div class="icon">
+          <ion-icon name="location-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">
+          Restaurant St, Delicious City, London 9578, UK
+        </span>
+      </address>
+
+      <div class="separator"></div>
+
+      <div class="topbar-item item-2">
+        <div class="icon">
+          <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">Daily : 8.00 am to 10.00 pm</span>
+      </div>
+
+      <a href="tel:+11234567890" class="topbar-item link">
+        <div class="icon">
+          <ion-icon name="call-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">+1 123 456 7890</span>
+      </a>
+
+      <div class="separator"></div>
+
+      <a href="mailto:booking@restaurant.com" class="topbar-item link">
+        <div class="icon">
+          <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">booking@restaurant.com</span>
+      </a>
+
+    </div>
+  </div>
+
+
+
+  <!--
+    - #HEADER
+  -->
+
+  <header class="header" data-header>
+    <div class="container">
+
+      <a href="index.html" class="logo">
+        <img src="./assets/images/logo.svg" width="160" height="50" alt="Grilli - Home">
+      </a>
+
+      <nav class="navbar" data-navbar>
+
+        <button class="close-btn" aria-label="close menu" data-nav-toggler>
+          <ion-icon name="close-outline" aria-hidden="true"></ion-icon>
+        </button>
+
+        <a href="index.html" class="logo">
+          <img src="./assets/images/logo.svg" width="160" height="50" alt="Grilli - Home">
+        </a>
+
+        <ul class="navbar-list">
+
+          <li class="navbar-item">
+            <a href="index.html#home" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Home</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="index.html#menu" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Menus</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="index.html#about" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">About Us</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="index.html#chefs" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Our Chefs</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="contact.html" class="navbar-link hover-underline active">
+              <div class="separator"></div>
+
+              <span class="span">Contact</span>
+            </a>
+          </li>
+
+        </ul>
+
+        <div class="text-center">
+          <p class="headline-1 navbar-title">Visit Us</p>
+
+          <address class="body-4">
+            Restaurant St, Delicious City, <br>
+            London 9578, UK
+          </address>
+
+          <p class="body-4 navbar-text">Open: 9.30 am - 2.30pm</p>
+
+          <a href="mailto:booking@grilli.com" class="body-4 sidebar-link">booking@grilli.com</a>
+
+          <div class="separator"></div>
+
+          <p class="contact-label">Booking Request</p>
+
+          <a href="tel:+88123123456" class="body-1 contact-number hover-underline">
+            +88-123-123456
+          </a>
+        </div>
+
+      </nav>
+
+      <a href="index.html#reservation" class="btn btn-secondary">
+        <span class="text text-1">Find A Table</span>
+
+        <span class="text text-2" aria-hidden="true">Find A Table</span>
+      </a>
+
+      <button class="nav-open-btn" aria-label="open menu" data-nav-toggler>
+        <span class="line line-1"></span>
+        <span class="line line-2"></span>
+        <span class="line line-3"></span>
+      </button>
+
+      <div class="overlay" data-nav-toggler data-overlay></div>
+
+    </div>
+  </header>
+
+
+
+  <main>
+    <article>
+
+      <!--
+        - #PAGE HERO
+      -->
+
+      <section class="section page-header has-bg-image text-center" aria-label="contact hero"
+        style="background-image: url('./assets/images/hero-slider-3.jpg')">
+        <div class="container">
+          <p class="section-subtitle label-2">Contact</p>
+
+          <h1 class="headline-1">We'd Love To Hear From You</h1>
+
+          <p class="section-text body-2">
+            Whether you are planning a celebration, booking a private dinner, or simply craving our signature dishes,
+            the Grilli team is ready to help.
+          </p>
+        </div>
+      </section>
+
+
+
+      <!--
+        - #CONTACT DETAILS
+      -->
+
+      <section class="section contact-details" aria-label="contact details">
+        <div class="container">
+          <div class="contact-wrapper">
+            <div class="contact-info">
+              <p class="section-subtitle label-2">Reach Out</p>
+
+              <h2 class="headline-1 section-title">Visit Our Restaurant</h2>
+
+              <p class="section-text">
+                Get in touch for reservations, private dining, or any questions about our seasonal menus. Our hospitality
+                team is always delighted to assist you.
+              </p>
+
+              <ul class="contact-list">
+                <li>
+                  <div class="contact-card">
+                    <div class="card-icon">
+                      <ion-icon name="location-outline" aria-hidden="true"></ion-icon>
+                    </div>
+
+                    <div>
+                      <p class="card-title title-2">Restaurant Address</p>
+
+                      <address class="body-4">
+                        Restaurant St, Delicious City, <br>
+                        London 9578, UK
+                      </address>
+                    </div>
+                  </div>
+                </li>
+
+                <li>
+                  <div class="contact-card">
+                    <div class="card-icon">
+                      <ion-icon name="call-outline" aria-hidden="true"></ion-icon>
+                    </div>
+
+                    <div>
+                      <p class="card-title title-2">Phone Numbers</p>
+
+                      <a href="tel:+88123123456" class="body-4 contact-link hover-underline">Booking Request :
+                        +88-123-123456</a>
+                      <a href="tel:+84912345678" class="body-4 contact-link hover-underline">General Inquiries :
+                        +84 912 345 678</a>
+                    </div>
+                  </div>
+                </li>
+
+                <li>
+                  <div class="contact-card">
+                    <div class="card-icon">
+                      <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
+                    </div>
+
+                    <div>
+                      <p class="card-title title-2">Email</p>
+
+                      <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
+                      <a href="mailto:hello@grilli.example" class="body-4 contact-link hover-underline">hello@grilli.example</a>
+                    </div>
+                  </div>
+                </li>
+
+                <li>
+                  <div class="contact-card">
+                    <div class="card-icon">
+                      <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
+                    </div>
+
+                    <div>
+                      <p class="card-title title-2">Opening Hours</p>
+
+                      <p class="body-4">Lunch : 11.00 am - 2.30 pm</p>
+                      <p class="body-4">Dinner : 05.00 pm - 10.00 pm</p>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+
+            <div class="contact-map">
+              <iframe
+                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1984.8453999382092!2d-0.12764738461290486!3d51.507321979635524!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b3339a9a6b9%3A0xdeb6a9d8b2666eb!2sLondon%2C%20UK!5e0!3m2!1sen!2suk!4v1697040000000!5m2!1sen!2suk"
+                width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade" title="Grilli restaurant on Google Maps"></iframe>
+            </div>
+          </div>
+        </div>
+      </section>
+
+
+
+      <!--
+        - #CONTACT FORM
+      -->
+
+      <section class="section contact-form" aria-label="contact form">
+        <div class="container">
+          <div class="form reservation-form bg-black-10">
+
+            <form action="" class="form-left">
+              <h2 class="headline-1 text-center">Send A Message</h2>
+
+              <p class="form-text text-center">
+                Prefer to write? Share your message below and a member of the Grilli team will reply shortly.
+              </p>
+
+              <div class="input-wrapper">
+                <input type="text" name="full-name" placeholder="Your Name" autocomplete="off" class="input-field">
+
+                <input type="email" name="email" placeholder="Email Address" autocomplete="off" class="input-field">
+              </div>
+
+              <div class="input-wrapper">
+                <input type="tel" name="phone" placeholder="Phone Number" autocomplete="off" class="input-field">
+
+                <input type="text" name="subject" placeholder="Subject" autocomplete="off" class="input-field">
+              </div>
+
+              <textarea name="message" placeholder="Message" autocomplete="off" class="input-field"></textarea>
+
+              <button type="submit" class="btn btn-secondary">
+                <span class="text text-1">Send Message</span>
+
+                <span class="text text-2" aria-hidden="true">Send Message</span>
+              </button>
+            </form>
+
+            <div class="form-right text-center" style="background-image: url('./assets/images/form-pattern.png')">
+
+              <h2 class="headline-1 text-center">Booking Request</h2>
+
+              <p class="contact-label">Call Us</p>
+
+              <a href="tel:+88123123456" class="body-1 contact-number hover-underline">+88-123-123456</a>
+
+              <div class="separator"></div>
+
+              <p class="contact-label">Email</p>
+
+              <a href="mailto:booking@grilli.com" class="body-4 contact-link hover-underline">booking@grilli.com</a>
+
+              <div class="separator"></div>
+
+              <p class="contact-label">Opening Hours</p>
+
+              <p class="body-4">
+                Monday to Sunday <br>
+                11.00 am - 10.00 pm
+              </p>
+
+            </div>
+
+          </div>
+        </div>
+      </section>
+
+    </article>
+  </main>
+
+
+
+  <!--
+    - #FOOTER
+  -->
+
+  <footer class="footer section has-bg-image text-center"
+    style="background-image: url('./assets/images/footer-bg.jpg')">
+    <div class="container">
+
+      <div class="footer-top grid-list">
+
+        <div class="footer-brand has-before has-after">
+
+          <a href="index.html" class="logo">
+            <img src="./assets/images/logo.svg" width="160" height="50" loading="lazy" alt="grilli home">
+          </a>
+
+          <address class="body-4">
+            Restaurant St, Delicious City, <br>
+            London 9578, UK
+          </address>
+
+          <a href="mailto:booking@grilli.com" class="body-4 contact-link">booking@grilli.com</a>
+
+          <a href="tel:+88123123456" class="body-4 contact-link">Booking Request : +88-123-123456</a>
+
+          <p class="body-4">
+            Open : 09:00 am - 01:00 pm
+          </p>
+
+          <div class="wrapper">
+            <div class="separator"></div>
+            <div class="separator"></div>
+            <div class="separator"></div>
+          </div>
+
+          <p class="title-1">Get News & Offers</p>
+
+          <p class="label-1">
+            Subscribe us & Get <span class="span">25% Off.</span>
+          </p>
+
+          <form action="" class="input-wrapper">
+            <div class="icon-wrapper">
+              <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
+
+              <input type="email" name="email_address" placeholder="Your email" autocomplete="off" class="input-field">
+            </div>
+
+            <button type="submit" class="btn btn-secondary">
+              <span class="text text-1">Subscribe</span>
+
+              <span class="text text-2" aria-hidden="true">Subscribe</span>
+            </button>
+          </form>
+
+        </div>
+
+        <ul class="footer-list">
+
+          <li>
+            <a href="index.html#home" class="label-2 footer-link hover-underline">Home</a>
+          </li>
+
+          <li>
+            <a href="index.html#menu" class="label-2 footer-link hover-underline">Menus</a>
+          </li>
+
+          <li>
+            <a href="index.html#about" class="label-2 footer-link hover-underline">About Us</a>
+          </li>
+
+          <li>
+            <a href="index.html#chefs" class="label-2 footer-link hover-underline">Our Chefs</a>
+          </li>
+
+          <li>
+            <a href="contact.html" class="label-2 footer-link hover-underline">Contact</a>
+          </li>
+
+        </ul>
+
+        <ul class="footer-list">
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Facebook</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Instagram</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Twitter</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Youtube</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Google Map</a>
+          </li>
+
+        </ul>
+
+      </div>
+
+      <div class="footer-bottom">
+
+        <p class="copyright">
+          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee"
+            target="_blank" class="link">codewithsadee</a>
+        </p>
+
+      </div>
+
+    </div>
+  </footer>
+
+
+
+  <!--
+    - #BACK TO TOP
+  -->
+
+  <a href="#top" class="back-top-btn active" aria-label="back to top" data-back-top-btn>
+    <ion-icon name="chevron-up" aria-hidden="true"></ion-icon>
+  </a>
+
+
+
+  <!--
+    - custom js link
+  -->
+  <script src="./assets/js/script.js"></script>
+
+  <!--
+    - ionicon link
+  -->
+  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+
+</body>
+
+</html>

--- a/menu.html
+++ b/menu.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!--
+    - primary meta tags
+  -->
+  <title>Grilli - Our Menu</title>
+  <meta name="title" content="Grilli - Our Menu">
+  <meta name="description" content="Browse the full Grilli menu and discover seasonal starters, mains, desserts, and crafted drinks.">
+
+  <!--
+    - favicon
+  -->
+  <link rel="shortcut icon" href="./favicon.svg" type="image/svg+xml">
+
+  <!--
+    - google font link
+  -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Forum&display=swap" rel="stylesheet">
+
+  <!--
+    - custom css link
+  -->
+  <link rel="stylesheet" href="./assets/css/style.css">
+
+  <!--
+    - preload images
+  -->
+  <link rel="preload" as="image" href="./assets/images/hero-slider-2.jpg">
+</head>
+
+<body id="top">
+
+  <!--
+    - #PRELOADER
+  -->
+
+  <div class="preload" data-preaload>
+    <div class="circle"></div>
+    <p class="text">Grilli</p>
+  </div>
+
+
+
+  <!--
+    - #TOP BAR
+  -->
+
+  <div class="topbar">
+    <div class="container">
+
+      <address class="topbar-item">
+        <div class="icon">
+          <ion-icon name="location-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">
+          Restaurant St, Delicious City, London 9578, UK
+        </span>
+      </address>
+
+      <div class="separator"></div>
+
+      <div class="topbar-item item-2">
+        <div class="icon">
+          <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">Daily : 8.00 am to 10.00 pm</span>
+      </div>
+
+      <a href="tel:+11234567890" class="topbar-item link">
+        <div class="icon">
+          <ion-icon name="call-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">+1 123 456 7890</span>
+      </a>
+
+      <div class="separator"></div>
+
+      <a href="mailto:booking@restaurant.com" class="topbar-item link">
+        <div class="icon">
+          <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
+        </div>
+
+        <span class="span">booking@restaurant.com</span>
+      </a>
+
+    </div>
+  </div>
+
+
+
+  <!--
+    - #HEADER
+  -->
+
+  <header class="header" data-header>
+    <div class="container">
+
+      <a href="index.html" class="logo">
+        <img src="./assets/images/logo.svg" width="160" height="50" alt="Grilli - Home">
+      </a>
+
+      <nav class="navbar" data-navbar>
+
+        <button class="close-btn" aria-label="close menu" data-nav-toggler>
+          <ion-icon name="close-outline" aria-hidden="true"></ion-icon>
+        </button>
+
+        <a href="index.html" class="logo">
+          <img src="./assets/images/logo.svg" width="160" height="50" alt="Grilli - Home">
+        </a>
+
+        <ul class="navbar-list">
+
+          <li class="navbar-item">
+            <a href="index.html" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Home</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="menu.html" class="navbar-link hover-underline active" aria-current="page">
+              <div class="separator"></div>
+
+              <span class="span">Menus</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="about.html" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">About Us</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="chefs.html" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Our Chefs</span>
+            </a>
+          </li>
+
+          <li class="navbar-item">
+            <a href="contact.html" class="navbar-link hover-underline">
+              <div class="separator"></div>
+
+              <span class="span">Contact</span>
+            </a>
+          </li>
+
+        </ul>
+
+        <div class="text-center">
+          <p class="headline-1 navbar-title">Visit Us</p>
+
+          <address class="body-4">
+            Restaurant St, Delicious City, <br>
+            London 9578, UK
+          </address>
+
+          <p class="body-4 navbar-text">Open: 9.30 am - 2.30pm</p>
+
+          <a href="mailto:booking@grilli.com" class="body-4 sidebar-link">booking@grilli.com</a>
+
+          <div class="separator"></div>
+
+          <p class="contact-label">Booking Request</p>
+
+          <a href="tel:+88123123456" class="body-1 contact-number hover-underline">
+            +88-123-123456
+          </a>
+        </div>
+
+      </nav>
+
+      <a href="index.html#reservation" class="btn btn-secondary">
+        <span class="text text-1">Find A Table</span>
+
+        <span class="text text-2" aria-hidden="true">Find A Table</span>
+      </a>
+
+      <button class="nav-open-btn" aria-label="open menu" data-nav-toggler>
+        <span class="line line-1"></span>
+        <span class="line line-2"></span>
+        <span class="line line-3"></span>
+      </button>
+
+      <div class="overlay" data-nav-toggler data-overlay></div>
+
+    </div>
+  </header>
+
+
+
+  <main>
+    <article>
+
+      <!--
+        - #PAGE HERO
+      -->
+
+      <section class="section page-header has-bg-image text-center" aria-label="menu hero"
+        style="background-image: url('./assets/images/hero-slider-2.jpg')">
+        <div class="container">
+          <p class="section-subtitle label-2">Our Menu</p>
+
+          <h1 class="headline-1">Discover Every Flavor</h1>
+
+          <p class="section-text body-2">
+            From the first bite to the final toast, explore the dishes and drinks crafted by our culinary team.
+          </p>
+        </div>
+      </section>
+
+
+
+      <!--
+        - #MENU FILTER
+      -->
+
+      <section class="section menu-page" aria-label="menu categories">
+        <div class="container" data-menu-filter>
+          <p class="section-subtitle text-center label-2">Categories</p>
+
+          <h2 class="headline-1 section-title text-center">Browse The Menu</h2>
+
+          <div class="filter-list" role="tablist" aria-label="Menu categories">
+            <button type="button" class="filter-btn active" data-filter-btn data-filter="all" role="tab"
+              aria-selected="true">All</button>
+            <button type="button" class="filter-btn" data-filter-btn data-filter="starters" role="tab"
+              aria-selected="false">Starters</button>
+            <button type="button" class="filter-btn" data-filter-btn data-filter="mains" role="tab"
+              aria-selected="false">Mains</button>
+            <button type="button" class="filter-btn" data-filter-btn data-filter="desserts" role="tab"
+              aria-selected="false">Desserts</button>
+            <button type="button" class="filter-btn" data-filter-btn data-filter="drinks" role="tab"
+              aria-selected="false">Drinks</button>
+          </div>
+
+          <ul class="grid-list" data-menu-grid>
+            <li data-menu-item data-category="starters">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-1.png" width="100" height="100" loading="lazy" alt="Heirloom Tomato Salad"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Heirloom Tomato Salad</span>
+                    </h3>
+
+                    <span class="badge label-1">Seasonal</span>
+
+                    <span class="span title-2">$18.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Sweet tomatoes, basil oil, burrata, and aged balsamic pearls.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="starters">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-5.png" width="100" height="100" loading="lazy" alt="Charred Octopus"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Charred Octopus</span>
+                    </h3>
+
+                    <span class="span title-2">$22.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Smoked paprika aioli, fingerling potatoes, and preserved lemon.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="mains">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-4.png" width="100" height="100" loading="lazy" alt="Wagyu Striploin"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Wagyu Striploin</span>
+                    </h3>
+
+                    <span class="badge label-1">Signature</span>
+
+                    <span class="span title-2">$48.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Miso-glazed wagyu, roasted garlic potato purée, charred broccolini.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="mains">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-2.png" width="100" height="100" loading="lazy" alt="Truffle Lasagne"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Truffle Lasagne</span>
+                    </h3>
+
+                    <span class="span title-2">$32.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    House pasta sheets, wild mushrooms, ricotta, and black truffle cream.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="desserts">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-3.png" width="100" height="100" loading="lazy" alt="Salted Caramel Tart"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Salted Caramel Tart</span>
+                    </h3>
+
+                    <span class="span title-2">$14.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Dark chocolate crust, caramel ganache, vanilla bean chantilly.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="desserts">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/menu-6.png" width="100" height="100" loading="lazy" alt="Citrus Pavlova"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Citrus Pavlova</span>
+                    </h3>
+
+                    <span class="span title-2">$13.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Crispy meringue, yuzu curd, ruby grapefruit, and mint.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="drinks">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/event-1.jpg" width="100" height="100" loading="lazy" alt="Smoked Old Fashioned"
+                    class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Smoked Old Fashioned</span>
+                    </h3>
+
+                    <span class="span title-2">$16.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Barrel-aged bourbon, smoked maple, bitters, orange zest.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+
+            <li data-menu-item data-category="drinks">
+              <div class="menu-card hover:card">
+
+                <figure class="card-banner img-holder" style="--width: 100; --height: 100;">
+                  <img src="./assets/images/event-2.jpg" width="100" height="100" loading="lazy"
+                    alt="Garden Tonic" class="img-cover">
+                </figure>
+
+                <div>
+
+                  <div class="title-wrapper">
+                    <h3 class="title-3">
+                      <span class="card-title">Garden Tonic</span>
+                    </h3>
+
+                    <span class="span title-2">$14.00</span>
+                  </div>
+
+                  <p class="card-text label-1">
+                    Botanical gin, cucumber cordial, tonic, basil blossoms.
+                  </p>
+
+                </div>
+
+              </div>
+            </li>
+          </ul>
+
+          <p class="menu-empty body-4" data-menu-empty hidden>No dishes match this category yet. Please choose another
+            selection.</p>
+        </div>
+      </section>
+
+
+
+      <!--
+        - #RESERVATION CTA
+      -->
+
+      <section class="section menu-cta" aria-label="menu reservation">
+        <div class="container">
+          <div class="menu-cta-card bg-black-10">
+            <div>
+              <p class="section-subtitle label-2">Chef's Recommendation</p>
+              <h2 class="headline-1 section-title">Pair Your Evening With Grilli</h2>
+              <p class="section-text">
+                Let our sommeliers and chefs curate the perfect tasting for your celebration. Reserve a table to enjoy
+                seasonal specials and bespoke cocktails.
+              </p>
+            </div>
+
+            <a href="index.html#reservation" class="btn btn-primary">
+              <span class="text text-1">Reserve Now</span>
+
+              <span class="text text-2" aria-hidden="true">Reserve Now</span>
+            </a>
+          </div>
+        </div>
+      </section>
+
+    </article>
+  </main>
+
+
+
+  <!--
+    - #FOOTER
+  -->
+
+  <footer class="footer section has-bg-image" style="background-image: url('./assets/images/footer-bg.jpg')">
+    <div class="container">
+
+      <div class="footer-top grid-list">
+
+        <div class="footer-brand has-before has-after">
+
+          <a href="index.html" class="logo">
+            <img src="./assets/images/logo.svg" width="160" height="50" loading="lazy" alt="grilli home">
+          </a>
+
+          <address class="body-4">
+            Restaurant St, Delicious City, <br>
+            London 9578, UK
+          </address>
+
+          <a href="mailto:booking@grilli.com" class="body-4 contact-link">booking@grilli.com</a>
+
+          <a href="tel:+88123123456" class="body-4 contact-link">Booking Request : +88-123-123456</a>
+
+          <p class="body-4">
+            Open : 09:00 am - 01:00 pm
+          </p>
+
+          <div class="wrapper">
+            <div class="separator"></div>
+            <div class="separator"></div>
+            <div class="separator"></div>
+          </div>
+
+          <p class="title-1">Get News & Offers</p>
+
+          <p class="label-1">
+            Subscribe us & Get <span class="span">25% Off.</span>
+          </p>
+
+          <form action="" class="input-wrapper">
+            <div class="icon-wrapper">
+              <ion-icon name="mail-outline" aria-hidden="true"></ion-icon>
+
+              <input type="email" name="email_address" placeholder="Your email" autocomplete="off" class="input-field">
+            </div>
+
+            <button type="submit" class="btn btn-secondary">
+              <span class="text text-1">Subscribe</span>
+
+              <span class="text text-2" aria-hidden="true">Subscribe</span>
+            </button>
+          </form>
+
+        </div>
+
+        <ul class="footer-list">
+
+          <li>
+            <a href="index.html" class="label-2 footer-link hover-underline">Home</a>
+          </li>
+
+          <li>
+            <a href="menu.html" class="label-2 footer-link hover-underline">Menus</a>
+          </li>
+
+          <li>
+            <a href="about.html" class="label-2 footer-link hover-underline">About Us</a>
+          </li>
+
+          <li>
+            <a href="chefs.html" class="label-2 footer-link hover-underline">Our Chefs</a>
+          </li>
+
+          <li>
+            <a href="contact.html" class="label-2 footer-link hover-underline">Contact</a>
+          </li>
+
+        </ul>
+
+        <ul class="footer-list">
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Facebook</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Instagram</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Twitter</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Youtube</a>
+          </li>
+
+          <li>
+            <a href="#" class="label-2 footer-link hover-underline">Google Map</a>
+          </li>
+
+        </ul>
+
+      </div>
+
+      <div class="footer-bottom">
+
+        <p class="copyright">
+          &copy; 2022 Grilli. All Rights Reserved | Crafted by <a href="https://github.com/codewithsadee" target="_blank"
+            class="link">codewithsadee</a>
+        </p>
+
+      </div>
+
+    </div>
+  </footer>
+
+
+
+  <!--
+    - #BACK TO TOP
+  -->
+
+  <a href="#top" class="back-top-btn active" aria-label="back to top" data-back-top-btn>
+    <ion-icon name="chevron-up" aria-hidden="true"></ion-icon>
+  </a>
+
+
+
+  <!--
+    - custom js link
+  -->
+  <script src="./assets/js/script.js"></script>
+
+  <!--
+    - ionicon link
+  -->
+  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated contact.html page that reuses the site's header, footer, and interactions while adding contact details, map, and inquiry form
- extend the shared stylesheet with contact page hero, info card, and responsive layout styles so the new page matches the existing look and feel

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6452c274483329dd4683a5948dedc